### PR TITLE
Fix linux package on ubuntu

### DIFF
--- a/mkosi.conf.d/ubuntu.conf
+++ b/mkosi.conf.d/ubuntu.conf
@@ -14,7 +14,7 @@ Packages=
 	iproute2
 	less
 	linux-firmware
-	linux-image-6.11.0-9-generic
+	linux-image-generic
 	locales
 	login
 	network-manager


### PR DESCRIPTION
Fixes ubuntu image generation, the old package doesn't exists on ubuntu repos only linux-image-generic