### PR TITLE
For qualcomm/uki and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,15 +168,26 @@ be selected.
 LLVM=1 ARCH=arm64 make -j99 pacman-pkg
 ```
 
+Copy the resulting **linux-upstream** files into *mkosi.packages* and make
+sure that **linux-upstream** is in the *Packages=* directive in
+*mkosi.conf.d/arch.conf*.
+
 ## Debian or Ubuntu
 ```
 LLVM=1 ARCH=arm64 make -j99 O=debian bindeb-pkg
 ```
 
+Copy the resulting **\*.deb** files into *mkosi.packages*. Use **dpkg-deb
+--into mkosi.packages ...** to acquire the **Package:** specifier of the kernel
+packet, then plug this into the *Packages=* directive in
+*mkosi.conf.d/debian.conf* or *mkosi.conf.d/ubuntu.conf*.
+
 ## Fedora
 ```
 LLVM=1 ARCH=arm64 make -j99 binrpm-pkg
 ```
+
+Copy **rpmbuild/RPMS/*.rpm** files into *mkosi.packages*.
 
 ### Note on compression and UEFI
 

--- a/README.md
+++ b/README.md
@@ -158,10 +158,6 @@ The upstream Linux kernel community aims to maintain *defconfig* to the point
 where necessary hardware drivers for running the kernel on supported Qualcomm
 hardware are enabled by default.
 
-The Arm64 build system does however by default produce a compressed kernel
-image (zImage), which a standard UEFI system will not decompress. It's
-therefore necessary to manually enable the **CONFIG_EFI_ZBOOT** option.
-
 Kernel packages can then be built for the various distributions using below
 commands and copied into **mkosi.packages**. Note that the *Packages* list in
 relevant *mkosi.conf.d* config might need to be updated for the new package to
@@ -181,6 +177,13 @@ LLVM=1 ARCH=arm64 make -j99 O=debian bindeb-pkg
 ```
 LLVM=1 ARCH=arm64 make -j99 binrpm-pkg
 ```
+
+### Note on compression and UEFI
+
+The provided ***mkosi.conf*** does enable the packaging of the kernel and
+related parts into a UKI. If you disable this, you need to make sure that the
+kernel is uncompressed, or built with the **CONFIG_EFI_ZBOOT** option, as UEFI
+does not decompress the kernel.
 
 ## Managing DeviceTree for your kernel
 

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -20,7 +20,13 @@ Hostname=mkosi-qcom
 
 PackageDirectories=mkosi.packages
 
-# Exclude the remoteproc drivers, so delay attempts at loading firmware until
-# the rootfs is present.
-KernelModulesInitrdExclude=
-	qcom_q6v5_pas
+# Be specific about which kernel modules to include in the ramdisk, for the
+# sake of saving space, as well as prevent qcom_q6v5_pas to be included (as
+# this would require remoteproc firmware to be included as well)
+KernelInitrdModules=
+	default
+	phy-qcom-qmp-pcie
+	phy-qcom-qmp-ufs
+	ufs-qcom
+	xor-neon
+	zstd_compress

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -12,8 +12,8 @@ Output=image
 [Content]
 Bootable=yes
 Bootloader=systemd-boot
-UnifiedKernelImages=no
-KernelModulesInitrd=no
+UnifiedKernelImages=unsigned
+KernelModulesInitrd=yes
 KernelCommandLine=clk_ignore_unused pd_ignore_unused audit=0 root=PARTLABEL=root-arm64 rootwait
 RootPassword=14
 Hostname=mkosi-qcom

--- a/mkosi.conf.d/debian.conf
+++ b/mkosi.conf.d/debian.conf
@@ -25,6 +25,7 @@ Packages=
 	qrtr-tools
 	rmtfs
 	systemd-boot
+	systemd-boot-efi
 	systemd-repart
 	systemd-timesyncd
 #	task-gnome-desktop

--- a/mkosi.conf.d/fedora.conf
+++ b/mkosi.conf.d/fedora.conf
@@ -10,6 +10,7 @@ Packages=
 	atheros-firmware
 	bash
 	coreutils
+	dnf
 	kernel
 	kmod
 	linux-firmware
@@ -18,6 +19,7 @@ Packages=
 	qcom-firmware
 	qrtr
 	rpm
+	shadow-utils
 	systemd
 	systemd-boot
 	systemd-udev


### PR DESCRIPTION
Updated configuration file to match changes in mkosi, updated to generate UKI to avoid CONFIG_EFI_ZBOOT requirements, polished the README and tested arch, debian, fedora, and ubuntu on the Particle Tachyon board (with custom kernel).