### PR TITLE
mkosi.extra: Disable systemd-networkd

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ experience of the built image.
 | file | Comments |
 | --- | --- |
 | 50-root.conf | Automatically extend the root partition (but not the file system) to cover the remainder of the disk |
-| 10-network-manager.preset | Make the NetworkManager systemd service launch automatically on boot (if present) |
+| 10-network-manager.preset | Enable NetworkManager and disable systemd-networkd services to avoid both stacks running at once |
 
 ### Runtime firmware
 

--- a/mkosi.extra/etc/systemd/system-preset/10-network-manager.preset
+++ b/mkosi.extra/etc/systemd/system-preset/10-network-manager.preset
@@ -1,1 +1,3 @@
 enable NetworkManager.service
+disable systemd-networkd.service
+disable systemd-networkd-wait-online.service


### PR DESCRIPTION
NetworkManager was explicitly enabled, systemd-networkd was left active. Disable the latter to avoid having two network managers running.