### PR TITLE
repart: Automatically grow the file system

### DIFF
--- a/mkosi.extra/etc/repart.d/50-root.conf
+++ b/mkosi.extra/etc/repart.d/50-root.conf
@@ -1,2 +1,3 @@
 [Partition]
 Type=root
+GrowFileSystem=yes


### PR DESCRIPTION
Only limited additional space is provided in the rootfs. The underlying partition is grown, but the file system needs to be grown manually.

Flag the rootfs to be automatically grown to fill the (already automatically grown) partition underneath.