### PR TITLE
fedora: Add btrfs tools

### DIFF
--- a/mkosi.conf.d/fedora.conf
+++ b/mkosi.conf.d/fedora.conf
@@ -6,6 +6,7 @@ Release=rawhide
 
 [Content]
 Packages=
+	btrfs-progs
 	NetworkManager
 	atheros-firmware
 	bash


### PR DESCRIPTION
Fedora uses btrfs, so install the package to allow managing this.